### PR TITLE
Settings manager

### DIFF
--- a/Client/Client.Qt/Settings.cpp
+++ b/Client/Client.Qt/Settings.cpp
@@ -7,7 +7,7 @@ Settings::Settings()
 
 std::unique_ptr<Settings> Settings::instance = nullptr;
 
-Settings &Settings::getInstance()
+Settings& Settings::getInstance()
 {
     if(instance == nullptr)
     {
@@ -21,17 +21,17 @@ Settings &Settings::getInstance()
 void Settings::writeSettings()
 {
     settings->beginGroup("Font");
-    settings->setValue("FontSize", fontSize);
+    settings->setValue("FontSize", _fontSize);
     settings->endGroup();
 }
 
 void Settings::setFontSize(int size)
 {
-    fontSize = size;
+    _fontSize = size;
 }
 
 int Settings::getFontSize()
 {
-    return fontSize;
+    return _fontSize;
 }
 

--- a/Client/Client.Qt/Settings.cpp
+++ b/Client/Client.Qt/Settings.cpp
@@ -1,0 +1,51 @@
+#include "Settings.hpp"
+#include <QDebug>
+#include <iostream>
+
+Settings::Settings()
+{
+    settings = std::make_unique<QSettings>();
+}
+
+std::unique_ptr<Settings> Settings::instance = nullptr;
+
+Settings &Settings::getInstance()
+{
+    if(instance == nullptr)
+    {
+        QCoreApplication::setOrganizationName("L&D C++ Lab");
+        QCoreApplication::setApplicationName("Juniorgram");
+        instance.reset(new Settings());
+        qDebug() << instance->fileName(); 
+    }
+    return *instance;
+}
+
+Settings::~Settings()
+{
+    std::cout<<"Settings Destructor\n";
+    if(instance.release() == nullptr){
+        std::cout<<"instance killed\n";
+    }
+    else{
+        std::cout<<"memory leak\n";
+    }
+}
+
+void Settings::WriteSettings()
+{
+    settings->beginGroup("Font");
+    settings->setValue("FontSize", fontSize);
+    settings->endGroup();
+}
+
+void Settings::setFontSize(int size)
+{
+    fontSize = size;
+}
+
+int Settings::getFontSize()
+{
+    return fontSize;
+}
+

--- a/Client/Client.Qt/Settings.hpp
+++ b/Client/Client.Qt/Settings.hpp
@@ -21,7 +21,7 @@ public:
      * @brief Method for getting reference to Settings instance.
      * @return Reference to Settings instance.
      */
-    static Settings &getInstance();
+    static Settings& getInstance();
     /**
      * @brief Destructor.
      */
@@ -43,5 +43,5 @@ public:
     int getFontSize();
 
 private:
-    int fontSize;
+    int _fontSize;
 };

--- a/Client/Client.Qt/Settings.hpp
+++ b/Client/Client.Qt/Settings.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <QApplication>
+#include <QSettings>
+#include <memory>
+
+class Settings : public QSettings{
+private:
+    Settings();
+    Settings(const Settings&) = delete;
+    Settings(Settings&&) = delete;
+    Settings& operator=(const Settings&) = delete;
+    Settings& operator=(Settings&&) = delete;
+    static std::unique_ptr<Settings> instance;
+    std::unique_ptr<QSettings> settings;
+
+public:
+    static Settings &getInstance();
+    ~Settings();
+    void WriteSettings();
+    void setFontSize(int size);
+    int getFontSize();
+
+private:
+    int fontSize;
+};

--- a/Client/Client.Qt/Settings.hpp
+++ b/Client/Client.Qt/Settings.hpp
@@ -3,6 +3,9 @@
 #include <QSettings>
 #include <memory>
 
+/** @class Settings
+ *  @brief Persistent settings
+ */
 class Settings : public QSettings{
 private:
     Settings();
@@ -14,10 +17,29 @@ private:
     std::unique_ptr<QSettings> settings;
 
 public:
+    /**
+     * @brief Method for getting reference to Settings instance.
+     * @return Reference to Settings instance.
+     */
     static Settings &getInstance();
+    /**
+     * @brief Destructor.
+     */
     ~Settings(){};
+    /**
+     * @brief Draft method for writting settings keys and /
+     * values to .config file.
+     */
     void writeSettings();
+    /**
+     * @brief Draft method for setting font size value
+     * @param size as int.
+     */
     void setFontSize(int size);
+    /**
+     * @brief Draft method for getting font size value
+     * @return fontSize as int.
+     */
     int getFontSize();
 
 private:


### PR DESCRIPTION
closes #84 
Settings class provides a way to read and write persistent settings.
Currently this class is not used but has been tested on TextEdit:

![image](https://user-images.githubusercontent.com/55056330/127356510-cac11c56-32c5-4aa6-8367-c9c153c1cae4.png)
![image](https://user-images.githubusercontent.com/55056330/127356803-b762ac20-2e12-476b-82dc-150232f3fe47.png)

![image](https://user-images.githubusercontent.com/55056330/127356590-73c83e1f-df43-4307-ab6c-a9ba2ac7a154.png)
![image](https://user-images.githubusercontent.com/55056330/127356604-f25933a2-7ea9-4d16-a1cd-557b91ec884c.png)

