### PR TITLE
Rollback qt cache

### DIFF
--- a/.github/workflows/Clang Linux Build.yml
+++ b/.github/workflows/Clang Linux Build.yml
@@ -36,14 +36,6 @@ jobs:
     - name: Get prerequisites
       run: python -m pip install conan==1.36.0 cmake && sudo apt install clang-12
 
-    - name: Cache Qt
-      id: qt-cache
-      uses: actions/cache@v2
-      with:
-        path: '/home/runner/work/Juniorgram/Juniorgram/Qt/'
-        key: ${{ runner.os }}${{matrix.BUILD_TYPE}}-qt
-        restore-keys: ${{ runner.os }}${{matrix.BUILD_TYPE}}-qt
-
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:

--- a/.github/workflows/GCC Linux Build.yml
+++ b/.github/workflows/GCC Linux Build.yml
@@ -38,14 +38,6 @@ jobs:
     - name: Get prerequisites
       run: python -m pip install conan==1.36.0 cmake
       
-    - name: Cache Qt
-      id: qt-cache
-      uses: actions/cache@v2
-      with:
-        path: '/home/runner/work/Juniorgram/Juniorgram/Qt/'
-        key: ${{ runner.os }}${{matrix.BUILD_TYPE}}-qt
-        restore-keys: ${{ runner.os }}${{matrix.BUILD_TYPE}}-qt
-      
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:

--- a/.github/workflows/Windows Build.yml
+++ b/.github/workflows/Windows Build.yml
@@ -26,14 +26,6 @@ jobs:
     - name: Get prerequisites
       run: python -m pip install conan==1.36.0 cmake
 
-    - name: Cache Qt
-      id: qt-cache
-      uses: actions/cache@v2
-      with:
-        path: 'D:\a\Juniorgram\Juniorgram\Qt\'
-        key: ${{ runner.os }}${{matrix.BUILD_TYPE}}-qt
-        restore-keys: ${{ runner.os }}${{matrix.BUILD_TYPE}}-qt
-
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:


### PR DESCRIPTION
Since cache only saves installed Qt folder there is not much point in doing that since aqtinstall still downloads the Qt installer and it's prerequisites.