### PR TITLE
Task 453: replaced std::cout with FileLogger in Network.Public

### DIFF
--- a/.github/workflows/Clang Linux Build.yml
+++ b/.github/workflows/Clang Linux Build.yml
@@ -35,7 +35,7 @@ jobs:
         architecture: 'x64'
         
     - name: Get prerequisites
-      run: python -m pip install conan==1.40.4 cmake && sudo apt install clang-12 clang-tidy
+      run: python -m pip install conan==1.43 cmake && sudo apt install clang-12 clang-tidy
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v2

--- a/.github/workflows/GCC Linux Build.yml
+++ b/.github/workflows/GCC Linux Build.yml
@@ -36,7 +36,7 @@ jobs:
         architecture: 'x64'
         
     - name: Get prerequisites
-      run: python -m pip install conan==1.41.0 cmake
+      run: python -m pip install conan==1.43 cmake
       
     - name: Install Qt
       uses: jurplel/install-qt-action@v2

--- a/Network/Public/CMakeLists.txt
+++ b/Network/Public/CMakeLists.txt
@@ -18,4 +18,4 @@ target_sources(${TARGET} INTERFACE ${SOURCE_FILES})
 
 target_include_directories(${TARGET} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/Include)
 
-target_link_libraries(${TARGET} INTERFACE Utility.Public CONAN_PKG::yas)
+target_link_libraries(${TARGET} INTERFACE Utility.Public CONAN_PKG::yas Base.Logger.Static)

--- a/Network/Public/Include/Network/Connection.hpp
+++ b/Network/Public/Include/Network/Connection.hpp
@@ -111,7 +111,11 @@ private:
                 }
                 else
                 {
-                    std::cout << "[" << mConnectionID << "] Write Header Fail.\n";
+                    Base::Logger::FileLogger::getInstance().log
+                    (
+                        '[' + std::to_string(mConnectionID) + "] Write Header Fail.\n",
+                        Base::Logger::LogLevel::ERR
+                    );
                     mSocket.close();
                 }
             };
@@ -146,7 +150,11 @@ private:
             }
             else
             {
-                std::cout << "[" << mConnectionID << "] Write Body Fail.\n";
+                Base::Logger::FileLogger::getInstance().log
+                (
+                    '[' + std::to_string(mConnectionID) + "] Write Body Fail.\n",
+                    Base::Logger::LogLevel::ERR
+                );
                 mSocket.close();
             }
         };
@@ -183,7 +191,11 @@ private:
             }
             else
             {
-                std::cout << "[" << mConnectionID << "] Read Header Fail.\n";
+                Base::Logger::FileLogger::getInstance().log
+                (
+                    '[' + std::to_string(mConnectionID) + "] Read Header Fail.\n",
+                    Base::Logger::LogLevel::ERR
+                );
                 mSocket.close();
             }
         };
@@ -221,7 +233,11 @@ private:
             }
             else
             {
-                std::cout << "[" << mConnectionID << "] Read Body Fail.\n";
+                Base::Logger::FileLogger::getInstance().log
+                (
+                    '[' + std::to_string(mConnectionID) + "] Read Body Fail.\n",
+                    Base::Logger::LogLevel::ERR
+                );
                 mSocket.close();
             }
         };

--- a/Network/Public/Include/Network/SerializationHandler.hpp
+++ b/Network/Public/Include/Network/SerializationHandler.hpp
@@ -369,9 +369,11 @@ private:
         }
         catch (const std::bad_any_cast& e)
         {
-            std::cout << e.what() << '\n';
-            std::cout << "Message body cann't be serialized\n";
-
+            Base::Logger::FileLogger::getInstance().log
+            (
+                std::string(e.what()) + "\nMessage body can't be serialized\n",
+                Base::Logger::LogLevel::ERR
+            );
             return SerializedState::FAILURE;
         }
     }
@@ -394,9 +396,11 @@ private:
         }
         catch (const std::bad_any_cast& e)
         {
-            std::cout << e.what() << '\n';
-            std::cout << "Message body cann't be deserialized\n";
-
+            Base::Logger::FileLogger::getInstance().log
+            (
+                std::string(e.what()) + "\nMessage body can't be deserialized\n",
+                Base::Logger::LogLevel::ERR
+            );
             return SerializedState::FAILURE;
         }
     }

--- a/Network/Public/Include/Network/YasSerializer.hpp
+++ b/Network/Public/Include/Network/YasSerializer.hpp
@@ -14,6 +14,8 @@ suppressWarning(4458, "-Wshadow")
 restoreWarning
 restoreWarning
 
+#include <FileLogger.hpp>
+
 #include "Network/Primitives.hpp"
 
     namespace Network
@@ -57,9 +59,11 @@ restoreWarning
             }
             catch (const std::exception& e)
             {
-                std::cout << "Serialization error\n";
-                std::cout << e.what() << '\n';
-
+                Base::Logger::FileLogger::getInstance().log
+                (
+                    std::string("Serialization error\n") + e.what() + '\n',
+                    Base::Logger::LogLevel::ERR
+                );
                 return SerializedState::FAILURE;
             }
 
@@ -82,9 +86,10 @@ restoreWarning
             }
             catch (const std::exception& e)
             {
-                std::cout << "Deserialization error\n";
-                std::cout << e.what() << '\n';
-
+                Base::Logger::FileLogger::getInstance().log(
+                    std::string("Deserialization error\n") + e.what() + '\n',
+                    Base::Logger::LogLevel::ERR
+                );
                 return SerializedState::FAILURE;
             }
 


### PR DESCRIPTION
I've used LogLevel as ERR for all messages in Network.
Do you have any other points of view on it?