### PR TITLE
Change date representation in database

### DIFF
--- a/Client/Client.Core/Client.Core.Static/Client.cpp
+++ b/Client/Client.Core/Client.Core.Static/Client.cpp
@@ -287,8 +287,11 @@ void Client::loop()
     while (!_incomingMessagesQueue.empty())
     {
         const Message message = _incomingMessagesQueue.pop_front();
-        std::string   output  = "[" + std::to_string(message.mHeader.mTimestamp.time_since_epoch().count()) + "]\n";
-        std::cout << output;
+        auto          _realtime   = std::chrono::system_clock::to_time_t;
+        std::tm       output_time = Utility::safe_localtime(_realtime(message.mHeader.mTimestamp));
+
+        std::cout << "[" << std::put_time(&output_time, "%F %T%z") << "]\n";
+
         switch (message.mHeader.mMessageType)
         {
             case MessageType::LoginAnswer:

--- a/Client/Client.Core/Client.Core.Static/Client.cpp
+++ b/Client/Client.Core/Client.Core.Static/Client.cpp
@@ -287,8 +287,8 @@ void Client::loop()
     while (!_incomingMessagesQueue.empty())
     {
         const Message message = _incomingMessagesQueue.pop_front();
-        auto          _realtime   = std::chrono::system_clock::to_time_t;
-        std::tm       output_time = Utility::safe_localtime(_realtime(message.mHeader.mTimestamp));
+        auto          convertTime = std::chrono::system_clock::to_time_t;
+        std::tm       output_time = Utility::safe_localtime(convertTime(message.mHeader.mTimestamp));
 
         std::cout << "[" << std::put_time(&output_time, "%F %T%z") << "]\n";
 

--- a/DataAccess/DataAccess.Postgre/PostgreRepositories.cpp
+++ b/DataAccess/DataAccess.Postgre/PostgreRepositories.cpp
@@ -182,7 +182,7 @@ std::vector<Network::MessageInfo> MessagesRepository::getMessageHistory(const st
         {
             mi.msgID        = value[0].as<std::uint64_t>();
             mi.senderID     = value[1].as<std::uint64_t>();
-            mi.time         = static_cast<std::int64_t>(value[2].as<double>());
+            mi.time         = value[2].as<std::time_t>();
             mi.message      = value[3].as<std::string>();
             mi.userLogin    = value[4].as<std::string>();
             mi.reactions[0] = value[6].as<std::uint32_t>();

--- a/Network/Public/Include/Network/Primitives.hpp
+++ b/Network/Public/Include/Network/Primitives.hpp
@@ -182,7 +182,7 @@ struct MessageInfo
     /// recipient ID uint64_t variable
     std::uint64_t recipientID;
     /// time in milliseconds since Epoch (1970-01-01 00:00:00 UTC)
-    std::int64_t time = Utility::millisecondsSinceEpoch();
+    std::uint64_t time = Utility::millisecondsSinceEpoch();
     /// reactions (reaction_id, reaction_count)
     std::map<std::uint32_t, std::uint32_t> reactions = {};
 

--- a/Utility/Utility.Public/Include/Utility/Utility.hpp
+++ b/Utility/Utility.Public/Include/Utility/Utility.hpp
@@ -221,9 +221,10 @@ inline std::string removeSpaces(const std::string& input)
 /**
  * @brief Returns time in milliseconds since Epoch (1970-01-01 00:00:00 UTC)
  */
-inline std::int64_t millisecondsSinceEpoch()
+inline std::uint64_t millisecondsSinceEpoch()
 {
-    return static_cast<std::int64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+    auto timeSinceEpoch = std::chrono::system_clock::now().time_since_epoch();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(timeSinceEpoch).count();
 }
 
 }  // namespace Utility


### PR DESCRIPTION
## Back/timestamp:

Changing the time data type in PostgreRepositories.hpp to properly convert the time in the database: The time_t type can represent the system time and date as some integer, so I chose this type. Also changed the time field in Primitivez.hpp from std::int32_t to std::uint64_t to protect against a negative time value. 

Added correct output of time in Client console: now instead of milliseconds time with time zone is output. 

## Results:
The time is now displayed properly in the database:
![image](https://user-images.githubusercontent.com/70116007/157902051-9aeeb4da-6ccf-45d3-a91e-2d286e3a7145.png)

Time output in Client console:
![image](https://user-images.githubusercontent.com/70116007/157902645-69a23621-9182-4162-9f05-19811c230b92.png)


