### PR TITLE
Transfer part of project Data access to use a Logger

### DIFF
--- a/DataAccess/DataAccess.Postgre/PostgreRepositories.cpp
+++ b/DataAccess/DataAccess.Postgre/PostgreRepositories.cpp
@@ -603,7 +603,7 @@ Utility::StoringReplyCodes RepliesRepository::storeReply(const Network::ReplyInf
     if (!firstResult.has_value())
     {
         Base::Logger::FileLogger::getInstance().log(
-            "Insert reply into 'replies' table failed\n",
+            "Inserting reply into 'replies' table failed\n",
             Base::Logger::LogLevel::ERR);
 
         return Utility::StoringReplyCodes::FAILED;
@@ -615,7 +615,7 @@ Utility::StoringReplyCodes RepliesRepository::storeReply(const Network::ReplyInf
     if (!secondResult.has_value())
     {
         Base::Logger::FileLogger::getInstance().log(
-            "Insert reply into 'channel_replies' table failed\n",
+            "Inserting reply into 'channel_replies' table failed\n",
             Base::Logger::LogLevel::ERR);
 
         return Utility::StoringReplyCodes::FAILED;
@@ -659,6 +659,7 @@ Utility::DirectMessageStatus DirectMessageRepository::addDirectChat(uint64_t use
 
         return Utility::DirectMessageStatus::FAILED;
     }
+
     pTable->changeTable("channels");
     auto adapter   = pTable->getAdapter();
     auto minUserId = std::to_string(std::min(user_id, receiverId));
@@ -686,7 +687,7 @@ Utility::DirectMessageStatus DirectMessageRepository::addDirectChat(uint64_t use
     }
 
     Base::Logger::FileLogger::getInstance().log(
-        "Creating direct char failed\n",
+        "Creating direct chat failed\n",
         Base::Logger::LogLevel::ERR);
 
     return Utility::DirectMessageStatus::FAILED;

--- a/DataAccess/DataAccess.Postgre/PostgreRepositories.cpp
+++ b/DataAccess/DataAccess.Postgre/PostgreRepositories.cpp
@@ -36,9 +36,7 @@ Utility::ChannelLeaveCodes ChannelsRepository::leaveChannel(const Network::Chann
     if (!findIdChannel.has_value())
     {
         Base::Logger::FileLogger::getInstance().log(
-            '[' + "channel id: " + 
-            std::to_string(findIdChannel.value()[0][0].as<std::uint64_t>()) +
-            "] Channel was not found\n",
+            "Leaving from channel failed because channel was not found\n ",
             Base::Logger::LogLevel::WARNING);
 
         return Utility::ChannelLeaveCodes::CHANNEL_NOT_FOUND;
@@ -69,8 +67,7 @@ Utility::ChannelLeaveCodes ChannelsRepository::leaveChannel(const Network::Chann
     else
     {
         Base::Logger::FileLogger::getInstance().log(
-            '[' + "channel id: " + std::to_string(findChannel.value()[0][1].as<std::uint64_t>()) +
-            "] Channel was not found\n",
+            "Leaving from channel failed because channel was not found\n ",
             Base::Logger::LogLevel::WARNING);
 
         return Utility::ChannelLeaveCodes::CHANNEL_NOT_FOUND;
@@ -91,9 +88,7 @@ Utility::ChannelDeleteCode ChannelsRepository::deleteChannel(const Network::Chan
     if (!findChannel.has_value())
     {
         Base::Logger::FileLogger::getInstance().log(
-            '[' + "channel id: " + 
-            std::to_string(findChannel.value()[0][1].as<std::uint64_t>()) +
-            "] Channel was not found\n",
+            "Deleting channel failed because channel was not found\n ",
             Base::Logger::LogLevel::WARNING);
 
         return Utility::ChannelDeleteCode::CHANNEL_NOT_FOUND;
@@ -106,7 +101,7 @@ Utility::ChannelDeleteCode ChannelsRepository::deleteChannel(const Network::Chan
         Base::Logger::FileLogger::getInstance().log(
             '['+ "channel id: " + std::to_string(channelID) + 
             "] User id " + std::to_string(creatorlID) +
-            " is not the creator of channel id " + std::to_string(channelID)+"\n",
+            " is not the creator of this channel\n",
             Base::Logger::LogLevel::INFO);
 
         return Utility::ChannelDeleteCode::CHANNEL_IS_NOT_USER;

--- a/DataAccess/DataAccess.Postgre/PostgreRepositories.cpp
+++ b/DataAccess/DataAccess.Postgre/PostgreRepositories.cpp
@@ -37,7 +37,7 @@ Utility::ChannelLeaveCodes ChannelsRepository::leaveChannel(const Network::Chann
     {
         Base::Logger::FileLogger::getInstance().log(
             "Leaving from channel failed because channel was not found\n ",
-            Base::Logger::LogLevel::WARNING);
+            Base::Logger::LogLevel::ERR);
 
         return Utility::ChannelLeaveCodes::CHANNEL_NOT_FOUND;
     }
@@ -68,7 +68,7 @@ Utility::ChannelLeaveCodes ChannelsRepository::leaveChannel(const Network::Chann
     {
         Base::Logger::FileLogger::getInstance().log(
             "Leaving from channel failed because channel was not found\n ",
-            Base::Logger::LogLevel::WARNING);
+            Base::Logger::LogLevel::ERR);
 
         return Utility::ChannelLeaveCodes::CHANNEL_NOT_FOUND;
     }
@@ -376,7 +376,7 @@ Utility::EditingMessageCodes MessagesRepository::editMessage(const Network::Mess
     {
         Base::Logger::FileLogger::getInstance().log(
             '[' +"channel id: "+ std::to_string(mi.channelID) +']' +
-            " Editing message failed\n",
+            " Editing message failed because message was not found\n",
             Base::Logger::LogLevel::ERR);
 
         return Utility::EditingMessageCodes::FAILED;
@@ -423,7 +423,7 @@ Utility::RegistrationCodes RegisterRepository::registerUser(const Network::Regis
     pTable->Insert()->columns(userData)->execute();
 
      Base::Logger::FileLogger::getInstance().log(
-         "User successfully registered",
+         "User successfully registered\n",
          Base::Logger::LogLevel::INFO);
 
     return Utility::RegistrationCodes::SUCCESS;
@@ -433,6 +433,9 @@ Utility::ReactionMessageCodes MessagesRepository::updateMessageReactions(const N
 {
     using Utility::ReactionMessageCodes;
 
+    /*
+    * @todo move reactionNames to Base
+    */
     const std::vector<std::string> reactionNames = { "likes", "dislikes", "fires", "cats", "smiles" };
 
     auto reactionInfo = std::find_if(mi.reactions.cbegin(), mi.reactions.cend(),
@@ -441,7 +444,7 @@ Utility::ReactionMessageCodes MessagesRepository::updateMessageReactions(const N
     if (reactionInfo == mi.reactions.end())
     {
         Base::Logger::FileLogger::getInstance().log(
-            "Invalid reaction info supplied",
+            "Updating message reaction failed because providing reaction was not found\n",
             Base::Logger::LogLevel::ERR);
 
         return ReactionMessageCodes::FAILED;

--- a/DataAccess/Public/Include/DataAccess/SQLStatements.hpp
+++ b/DataAccess/Public/Include/DataAccess/SQLStatements.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <Utility/Exception.hpp>
 #include <Utility/SQLUtility.hpp>
+#include <FileLogger.hpp>
 #include <any>
 #include <iostream>
 #include <optional>
@@ -237,11 +238,7 @@ public:
                 throw Utility::OperationDBException("Database connection failure!", __FILE__, __LINE__);
             }
         }
-        /*catch (const pqxx::sql_error& err)
-        {
-            std::cerr << err.what() << '\n';
-            std::cerr << err.query() << '\n';
-        }*/
+
         catch (const std::exception& err)
         {
             Base::Logger::FileLogger::getInstance().log(

--- a/DataAccess/Public/Include/DataAccess/SQLStatements.hpp
+++ b/DataAccess/Public/Include/DataAccess/SQLStatements.hpp
@@ -244,7 +244,9 @@ public:
         }*/
         catch (const std::exception& err)
         {
-            std::cerr << err.what() << '\n';
+            Base::Logger::FileLogger::getInstance().log(
+                std::string(err.what() + '\n'),
+                Base::Logger::LogLevel::ERR);
         }
 
         this->rollback();


### PR DESCRIPTION
Task:
At the moment, the project has a utility for logging. Instead, we use output to standard error.
Do not do like this.
