### PR TITLE
Investigate the cause of a crash after a failed registration

### DIFF
--- a/Client/Client.Core/Client.Core.Static/Client.cpp
+++ b/Client/Client.Core/Client.Core.Static/Client.cpp
@@ -55,14 +55,14 @@ bool Client::connectToServer(const std::string_view& host, const uint16_t port)
 
 bool Client::reconnectToServer()
 {
+    //ToDo::Server exception handling
     if (_serverAccept == false)
     {
+        _contextThread.detach();
         _context.reset();
         _connection.reset();
-        _contextThread.detach();
 
         //ToDo: Save other information from Server after Reconnect Part
-        system("pause");
         connectToServer(ServerInfo::Address::remote, ServerInfo::Port::test);   
     }
     

--- a/Client/Client.Core/Client.Core.Static/Client.hpp
+++ b/Client/Client.Core/Client.Core.Static/Client.hpp
@@ -18,6 +18,8 @@ public:
 
     /// Connect to server with IP(host) and Port(port)
     bool connectToServer(const std::string_view& host, const uint16_t port);
+    /// Reconnect to server
+    bool reconnectToServer();
     /// Disconnect from server
     void disconnectFromServer();
 

--- a/Client/Client.Qt/Application.hpp
+++ b/Client/Client.Qt/Application.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <DataAccess.SQLite/LiteRepositoryContainer.hpp>
 #include <QApplication>
 #include <Style/Styles.hpp>
+#include <DataAccess.SQLite/LiteRepositoryContainer.hpp>
 #include <memory>
 
 #include "ConnectionManager.hpp"
@@ -57,7 +57,6 @@ public:
     std::unique_ptr<DataAccess::LiteRepositoryContainer>& repositoryContainer();
     /// Shows message as notification
     void showMessage(const QString& header, const QString& body, MessageType type = MessageType::Info, int msecs = 5000);
-
     /**
      * @brief Change app state
      * @param appState App state

--- a/Client/Client.Qt/ConnectionManager.cpp
+++ b/Client/Client.Qt/ConnectionManager.cpp
@@ -26,9 +26,8 @@ void ConnectionManager::init()
 void ConnectionManager::onReconnect()
 { 
     //ToDo: Fooes onResume && onPause from Reconnect Part
-    
     oApp->showMessage("Connection Status", "Server trying to connection!", MessageType::Warning);
-   
+    
     reconnectToServer();
     emit ReceiverManager::instance()->onServerAccepted();
 }

--- a/Client/Client.Qt/ConnectionManager.cpp
+++ b/Client/Client.Qt/ConnectionManager.cpp
@@ -26,6 +26,7 @@ void ConnectionManager::init()
 void ConnectionManager::onReconnect()
 { 
     //ToDo: Fooes onResume && onPause from Reconnect Part
+    
     oApp->showMessage("Connection Status", "Server trying to connection!", MessageType::Warning);
    
     reconnectToServer();

--- a/Client/Client.Qt/ConnectionManager.cpp
+++ b/Client/Client.Qt/ConnectionManager.cpp
@@ -23,6 +23,15 @@ void ConnectionManager::init()
     );
 }
 
+void ConnectionManager::onReconnect()
+{ 
+    //ToDo: Fooes onResume && onPause from Reconnect Part
+    oApp->showMessage("Connection Status", "Server trying to connection!", MessageType::Warning);
+   
+    reconnectToServer();
+    emit ReceiverManager::instance()->onServerAccepted();
+}
+
 void ConnectionManager::onServerAccepted()
 {
     oApp->showMessage("Connection Status", "Server accepted the connection!");
@@ -230,8 +239,9 @@ void ConnectionManager::onDisconnect()
 {
     disconnectFromServer();
     loginState = LoginState::FAILED;
-    oApp->showMessage("Connection Status", "You've been disconnected from server!", MessageType::Error);
+    oApp->showMessage("Connection Status", "You've been disconnected from server!");
     emit ReceiverManager::instance()->onDisconnect();
+    onReconnect();
 }
 
 void ConnectionManager::configureConnectionProperties()

--- a/Client/Client.Qt/ConnectionManager.hpp
+++ b/Client/Client.Qt/ConnectionManager.hpp
@@ -6,6 +6,7 @@
 #include "Network/Primitives.hpp"
 #include "ServerInfo.hpp"
 
+
 /// Login status
 enum class LoginState
 {
@@ -87,13 +88,15 @@ public:
 
     /// Initialize connection to server
     void init();
+    /// Initialize reconnection to server
+    void onReconnect(); 
     /// Default behavior
     virtual ~ConnectionManager() = default;
 
 protected:
     /// Disconnect handler
     void onDisconnect() override;
-
+    
     /// Login Answer handler
     void onLoginAnswer(bool success) override;
     /// Server Accepted handler

--- a/Client/Client.Qt/ConnectionManager.hpp
+++ b/Client/Client.Qt/ConnectionManager.hpp
@@ -96,7 +96,6 @@ public:
 protected:
     /// Disconnect handler
     void onDisconnect() override;
-    
     /// Login Answer handler
     void onLoginAnswer(bool success) override;
     /// Server Accepted handler


### PR DESCRIPTION
## Changes:
1. Gone infinite loading after disconnecting from the server.
2. Added function to reconnect to the server.

## What's incomplete: 
1. Small spinner widget after connection loss, so that it would be possible to track and monitor the break with the server (Chat page).
P.S. On other pages reconnection will be held in a hidden "mode".
2. Logging on connection break and reconnection to the server in the client and server.
3. Reconnection timer.