### PR TITLE
Changing of timestamp

### DIFF
--- a/Base/Logger/Logger.Static/FileLogger.cpp
+++ b/Base/Logger/Logger.Static/FileLogger.cpp
@@ -84,7 +84,8 @@ std::string FileLogger::timestamp()
     using UtilityTime::RTC;
     using UtilityTime::timestamp_t;
 
-    timestamp_t logMilliseconds = duration_cast<milliseconds>(RTC::now().time_since_epoch()).count() % 1000;
+    timestamp_t secDivider      = 1000;
+    timestamp_t logMilliseconds = duration_cast<milliseconds>(RTC::now().time_since_epoch()).count() % secDivider;
     timestamp_t rawTime         = system_clock::to_time_t(RTC::now());
 
     std::tm safeTime = safe_localtime(rawTime);

--- a/Base/Logger/Logger.Static/FileLogger.hpp
+++ b/Base/Logger/Logger.Static/FileLogger.hpp
@@ -21,7 +21,7 @@ class FileLogger : ILogger
 public:
     using BlockWrapper = std::pair<std::string, std::string>;
 
-    /**
+     /**
      * @brief Gets an object of the current class
      * @return object Logger
      */
@@ -119,6 +119,7 @@ private:
      * @return time format [yyyy.mm.dd. hh.mm.ss.ms]
      */
     static std::string timestamp();
+
     /**
      * @brief Marks to current thread
      * @return curent thread in string format


### PR DESCRIPTION
After figuring it out, I found out that the bug was in the wrong representation of time. 
Here is the current conclusion: 

[2022-08-09 16:15:12.518] [2788] [INFO] [SERVER] Started!
[2022-08-09 16:15:12.632] [9776] [INFO] [SERVER] New Connection: 172.20.10.2:56128
[2022-08-09 16:15:12.632] [9776] [INFO] [10000] Connection Approved
[2022-08-09 16:15:24.296] [7644] [INFO] 2 user logged successfully

[2022-08-09 16:15:24.296] [2788] [DEBUG] DEBUG: userID=2
[2022-08-09 16:15:24.297] [2788] [INFO] User 2 logged in.
[2022-08-09 16:15:29.474] [7644] [INFO] All channels are successfully given to client

[2022-08-09 16:15:29.479] [7644] [INFO] List of subscriptions of channel id: 162 was successfully given

[2022-08-09 16:15:34.084] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:34.087] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:35.075] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:35.076] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:36.072] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:36.074] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:37.071] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:37.072] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:38.071] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:38.073] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:39.073] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:39.074] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:40.071] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:40.072] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:41.071] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:41.072] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:42.073] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:42.075] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:42.754] [7644] [INFO] [channel id: 8] Message have stored successfully

[2022-08-09 16:15:43.072] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:43.074] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:44.073] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:44.074] [7644] [INFO] Reply history was successfully given

[2022-08-09 16:15:45.073] [7644] [INFO] [channel id: 8] Message history was successfully given to client

[2022-08-09 16:15:45.074] [7644] [INFO] Reply history was successfully given

