### PR TITLE
Creating of IQuery.hpp && IBuilder.hpp interfaces

### DIFF
--- a/DataAccess/DataAccess.Test/QueryBuilderTest.cpp
+++ b/DataAccess/DataAccess.Test/QueryBuilderTest.cpp
@@ -9,7 +9,7 @@ using DataAccess::IAdapter;
 
 TEST_CASE("QueryBuilder cover", "[dummy]")
 {
-	QueryBuilder<pqxx::result> testQueryBuilder(Utility::DatabaseType::DB_POSTGRE, "users",
+    QueryBuilder<pqxx::result> testQueryBuilder(Utility::DatabaseType::DB_POSTGRE, "users",
 								IAdapter::getInstance<DataAccess::PostgreAdapter>(DBOptions::test));
 
 	SECTION("Try to initialize the reference and catch the exception")

--- a/DataAccess/Public/CMakeLists.txt
+++ b/DataAccess/Public/CMakeLists.txt
@@ -10,7 +10,9 @@ set(SOURCE_FILES
         Include/DataAccess/IRepository.hpp
         Include/DataAccess/IServerRepositories.hpp
         Include/DataAccess/SQLStatements.hpp
-        Include/DataAccess/QueryBuilder.hpp
+		Include/DataAccess/IQuery.hpp
+		Include/DataAccess/IBuilder.hpp
+		Include/DataAccess/QueryBuilder.hpp
         Include/DataAccess/RepositoryRequest.hpp
         Include/DataAccess/FutureResult.hpp)
 

--- a/DataAccess/Public/Include/DataAccess/IBuilder.hpp
+++ b/DataAccess/Public/Include/DataAccess/IBuilder.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Utility/SQLUtility.hpp>
+#include <Utility/Utility.hpp>
+
+#include "SQLStatements.hpp"
+
+namespace DataAccess
+{
+/**
+* @class IBuilder
+* @brief IBuilder class.
+*/
+
+template<typename ResultType>
+class IBuilder
+{
+public:
+    virtual SQLSelect<ResultType>* Select() = 0;
+
+    virtual SQLInsert<ResultType>* Insert() = 0;
+
+    virtual SQLUpdate<ResultType>* Update() = 0;
+
+    virtual SQLDelete<ResultType>* Delete() = 0;
+
+    virtual void changeTable(const char* newTableName) noexcept = 0;
+
+    virtual void changeTable(const std::string& newTableName) noexcept = 0;
+
+    virtual void clearStatement() = 0;
+	
+    virtual ~IBuilder() = default;
+};
+}  // namespace DataAccess

--- a/DataAccess/Public/Include/DataAccess/IBuilder.hpp
+++ b/DataAccess/Public/Include/DataAccess/IBuilder.hpp
@@ -9,26 +9,16 @@ namespace DataAccess
 {
 /**
 * @class IBuilder
-* @brief IBuilder class.
+* @brief IBuilder interface.
 */
-
-template<typename ResultType>
 class IBuilder
 {
 public:
-    virtual SQLSelect<ResultType>* Select() = 0;
+    virtual [[nodiscard]] std::shared_ptr<IAdapter> getAdapter() const noexcept = 0;
 
-    virtual SQLInsert<ResultType>* Insert() = 0;
+    virtual [[nodiscard]] Utility::DatabaseType getDatabaseType() const noexcept = 0;
 
-    virtual SQLUpdate<ResultType>* Update() = 0;
-
-    virtual SQLDelete<ResultType>* Delete() = 0;
-
-    virtual void changeTable(const char* newTableName) noexcept = 0;
-
-    virtual void changeTable(const std::string& newTableName) noexcept = 0;
-
-    virtual void clearStatement() = 0;
+    virtual [[nodiscard]] const std::string& getCurrentTableName() const noexcept = 0;
 	
     virtual ~IBuilder() = default;
 };

--- a/DataAccess/Public/Include/DataAccess/IQuery.hpp
+++ b/DataAccess/Public/Include/DataAccess/IQuery.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <DataAccess/IAdapter.hpp>
+
 #include <Utility/Exception.hpp>
 #include <Utility/SQLUtility.hpp>
 #include <Utility/Utility.hpp>

--- a/DataAccess/Public/Include/DataAccess/IQuery.hpp
+++ b/DataAccess/Public/Include/DataAccess/IQuery.hpp
@@ -11,18 +11,26 @@
 namespace DataAccess
 {
 /**
- * @class IQuery
- * @brief IQuery class.
- */
-
+* @class IQuery
+* @brief IQuery interface.
+*/
+template <typename ResultType>
 class IQuery
 {
 public:
-    virtual [[nodiscard]] std::shared_ptr<IAdapter> getAdapter() const noexcept = 0;
+    virtual SQLSelect<ResultType>* Select() = 0;
 
-    virtual [[nodiscard]] Utility::DatabaseType getDatabaseType() const noexcept = 0;
+    virtual SQLInsert<ResultType>* Insert() = 0;
 
-    virtual [[nodiscard]] const std::string& getCurrentTableName() const noexcept = 0;
+    virtual SQLUpdate<ResultType>* Update() = 0;
+
+    virtual SQLDelete<ResultType>* Delete() = 0;
+
+    virtual void changeTable(const char* newTableName) noexcept = 0;
+
+    virtual void changeTable(const std::string& newTableName) noexcept = 0;
+
+    virtual void clearStatement() = 0;
 
     virtual ~IQuery() = default;
 };

--- a/DataAccess/Public/Include/DataAccess/IQuery.hpp
+++ b/DataAccess/Public/Include/DataAccess/IQuery.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <DataAccess/IAdapter.hpp>
+#include <Utility/Exception.hpp>
+#include <Utility/SQLUtility.hpp>
+#include <Utility/Utility.hpp>
+
+#include "SQLStatements.hpp"
+
+namespace DataAccess
+{
+/**
+ * @class IQuery
+ * @brief IQuery class.
+ */
+
+class IQuery
+{
+public:
+    virtual [[nodiscard]] std::shared_ptr<IAdapter> getAdapter() const noexcept = 0;
+
+    virtual [[nodiscard]] Utility::DatabaseType getDatabaseType() const noexcept = 0;
+
+    virtual [[nodiscard]] const std::string& getCurrentTableName() const noexcept = 0;
+
+    virtual ~IQuery() = default;
+};
+}  // namespace DataAccess

--- a/DataAccess/Public/Include/DataAccess/QueryBuilder.hpp
+++ b/DataAccess/Public/Include/DataAccess/QueryBuilder.hpp
@@ -33,7 +33,7 @@ public:
     {
     }
 
-    virtual ~QueryBuilder(void) { this->clearStatement(); }
+    virtual ~QueryBuilder() { this->clearStatement(); }
 
 public:
     QueryBuilder() = delete;

--- a/DataAccess/Public/Include/DataAccess/QueryBuilder.hpp
+++ b/DataAccess/Public/Include/DataAccess/QueryBuilder.hpp
@@ -15,9 +15,12 @@ namespace DataAccess
 /**
 * @class QueryBuilder
 * @brief QueryBuilder class.
+*   Class implements SQL queries, \
+*   such as Select, Insert, Update, \
+*   Delete and returns the corresponding object.
 */
 template <typename ResultType>
-class QueryBuilder : public IQuery, public IBuilder<ResultType>
+class QueryBuilder : public IQuery<ResultType>, public IBuilder
 {
 private:
     Utility::DatabaseType _databaseType;
@@ -42,16 +45,24 @@ public:
     QueryBuilder(QueryBuilder&&)        = delete;
 
     QueryBuilder& operator=(const QueryBuilder&)   = delete;
-    QueryBuilder& operator=(QueryBuilder&&)      = delete;
+    QueryBuilder& operator=(QueryBuilder&&)        = delete;
 
 public:
+    /**
+    * @brief SQL select query.
+    * @return SQLSelect pointer.
+    */
     SQLSelect<ResultType>* Select() override
     {
         if (_statement != nullptr)
         {
             if (_statement->getStatementType() != Utility::SQLStatement::ST_SELECT)
             {
-                throw Utility::OperationDBException("Previous query wasn't executed or rollbacked!", __FILE__, __LINE__);
+                throw Utility::OperationDBException
+                (
+                    "Previous query wasn't executed or rollbacked!",
+                    __FILE__, __LINE__
+                );
             }
         }
         else
@@ -64,16 +75,20 @@ public:
     }
 
     /**
-     * @brief SQL insert query.
-     * @return SQLInsert pointer.
-     */
+    * @brief SQL insert query.
+    * @return SQLInsert pointer.
+    */
     SQLInsert<ResultType>* Insert() override
     {
         if (_statement != nullptr)
         {
             if (_statement->getStatementType() != Utility::SQLStatement::ST_INSERT)
             {
-                throw Utility::OperationDBException("Previous query wasn't executed or rollbacked!", __FILE__, __LINE__);
+                throw Utility::OperationDBException
+                (
+                    "Previous query wasn't executed or rollbacked!", 
+                    __FILE__, __LINE__
+                );
             }
         }
         else
@@ -86,16 +101,20 @@ public:
     }
 
     /**
-     * @brief SQL update query.
-     * @return SQLUpdate pointer.
-     */
+    * @brief SQL update query.
+    * @return SQLUpdate pointer.
+    */
     SQLUpdate<ResultType>* Update() override
     {
         if (_statement != nullptr)
         {
             if (_statement->getStatementType() != Utility::SQLStatement::ST_UPDATE)
             {
-                throw Utility::OperationDBException("Previous query wasn't executed or rollbacked!", __FILE__, __LINE__);
+                throw Utility::OperationDBException
+                (
+                    "Previous query wasn't executed or rollbacked!",
+                    __FILE__, __LINE__
+                );
             }
         }
         else
@@ -108,16 +127,20 @@ public:
     }
 
     /**
-     * @brief SQL delete query.
-     * @return SQLDelete pointer.
-     */
+    * @brief SQL delete query.
+    * @return SQLDelete pointer.
+    */
     SQLDelete<ResultType>* Delete() override
     {
         if (_statement != nullptr)
         {
             if (_statement->getStatementType() != Utility::SQLStatement::ST_DELETE)
             {
-                throw Utility::OperationDBException("Previous query wasn't executed or rollbacked!", __FILE__, __LINE__);
+                throw Utility::OperationDBException
+                (
+                    "Previous query wasn't executed or rollbacked!",
+                    __FILE__, __LINE__
+                );
             }
         }
         else
@@ -131,9 +154,9 @@ public:
 
 public:
     /**
-     * @brief Changing table.
-     * @param newTableName - new name of the table.
-     */
+    * @brief Changing table.
+    * @param newTableName - new name of the table.
+    */
     void changeTable(const char* newTableName) noexcept override
     {
         if (_statement != nullptr)
@@ -145,27 +168,49 @@ public:
     }
 
     /**
-     * @brief Changing table.
-     * @param newTableName - new name of the table.
-     */
-    void changeTable(const std::string& newTableName) noexcept override { changeTable(newTableName.c_str()); }
+    * @brief Changing table.
+    * @param newTableName - new name of the table.
+    */
+    void changeTable(const std::string& newTableName) noexcept override
+    {
+        changeTable(newTableName.c_str()); 
+    }
 
 public:
     /**
-     * @brief Get postgreAdapter object.
-     * @return PostgreAdapter.
+    * @brief Get postgreAdapter object.
+    * @return PostgreAdapter.
+    */
+    [[nodiscard]] std::shared_ptr<IAdapter> getAdapter() const noexcept override 
+    {
+        return _adapter; 
+    }
+
+    /**
+    * @brief Get database type.
+    * @return DatabaseType.
+    */
+    [[nodiscard]] Utility::DatabaseType getDatabaseType() const noexcept override
+    {
+        return _databaseType; 
+    }
+
+     /**
+     * @brief Get current table name.
+     * @return tableName.
      */
-    [[nodiscard]] std::shared_ptr<IAdapter> getAdapter() const noexcept override { return _adapter; }
+    [[nodiscard]] const std::string& getCurrentTableName() const noexcept override 
+    {
+        return _tableName; 
+    }
 
-    [[nodiscard]] Utility::DatabaseType getDatabaseType() const noexcept override { return _databaseType; }
-
-    [[nodiscard]] const std::string& getCurrentTableName() const noexcept override { return _tableName; }
-
+    /**
+    * @brief clear SQL statements
+    */
     void clearStatement() override
     {
         delete _statement;
         _statement = nullptr;
     }
 };
-
 }  // namespace DataAccess

--- a/DataAccess/Public/Include/DataAccess/QueryBuilder.hpp
+++ b/DataAccess/Public/Include/DataAccess/QueryBuilder.hpp
@@ -68,7 +68,7 @@ public:
         else
         {
             _statement = Utility::make_statement<SQLSelect<ResultType>>(*this);
-            *_statement << "select ";
+            *_statement << " select ";
         }
 
         return dynamic_cast<SQLSelect<ResultType>*>(_statement);
@@ -94,7 +94,7 @@ public:
         else
         {
             _statement = Utility::make_statement<SQLInsert<ResultType>>(*this);
-            *_statement << "insert into " << this->getCurrentTableName();
+            *_statement << " insert into " << this->getCurrentTableName();
         }
 
         return dynamic_cast<SQLInsert<ResultType>*>(_statement);
@@ -120,7 +120,7 @@ public:
         else
         {
             _statement = Utility::make_statement<SQLUpdate<ResultType>>(*this);
-            *_statement << "update " << this->getCurrentTableName();
+            *_statement << " update " << this->getCurrentTableName();
         }
 
         return dynamic_cast<SQLUpdate<ResultType>*>(_statement);
@@ -146,7 +146,7 @@ public:
         else
         {
             _statement = Utility::make_statement<SQLDelete<ResultType>>(*this);
-            *_statement << "delete from " << this->getCurrentTableName();
+            *_statement << " delete from " << this->getCurrentTableName();
         }
 
         return dynamic_cast<SQLDelete<ResultType>*>(_statement);

--- a/DataAccess/Public/Include/DataAccess/QueryBuilder.hpp
+++ b/DataAccess/Public/Include/DataAccess/QueryBuilder.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <iostream>
-#include <string>
-
+#include <DataAccess/IQuery.hpp>
+#include <DataAccess/IBuilder.hpp>
 #include <DataAccess/IAdapter.hpp>
+
 #include <Utility/Exception.hpp>
 #include <Utility/SQLUtility.hpp>
 #include <Utility/Utility.hpp>
@@ -13,41 +13,39 @@
 namespace DataAccess
 {
 /**
- * @class QueryBuilder
- * @brief QueryBuilder class.
- */
+* @class QueryBuilder
+* @brief QueryBuilder class.
+*/
 template <typename ResultType>
-class QueryBuilder
+class QueryBuilder : public IQuery, public IBuilder<ResultType>
 {
 private:
-    Utility::DatabaseType       _databaseType;
-    std::string                 _tableName;
-    SQLBase<ResultType>*        _statement;
+    Utility::DatabaseType _databaseType;
+    std::string           _tableName;
+    SQLBase<ResultType>*  _statement;
 
 protected:
-    std::shared_ptr<IAdapter>   _adapter;
+    std::shared_ptr<IAdapter> _adapter;
 
 public:
     QueryBuilder(Utility::DatabaseType type, const std::string& tableName, std::shared_ptr<IAdapter> adapter)
-        : _databaseType{ type }, _tableName{ tableName }, _statement{ nullptr }, _adapter{ adapter } {}
+        : _databaseType{type}, _tableName{tableName}, _statement{nullptr}, _adapter{adapter}
+    {
+    }
 
     virtual ~QueryBuilder(void) { this->clearStatement(); }
 
 public:
     QueryBuilder() = delete;
 
-    QueryBuilder(const QueryBuilder&) = delete;
-    QueryBuilder(QueryBuilder&&)      = delete;
+    QueryBuilder(const QueryBuilder&)   = delete;
+    QueryBuilder(QueryBuilder&&)        = delete;
 
-    QueryBuilder& operator=(const QueryBuilder&) = delete;
-    QueryBuilder& operator=(QueryBuilder&&) = delete;
+    QueryBuilder& operator=(const QueryBuilder&)   = delete;
+    QueryBuilder& operator=(QueryBuilder&&)      = delete;
 
 public:
-    /**
-     * @brief SQL select query.
-     * @return SQLSelect pointer.
-     */
-    SQLSelect<ResultType>* Select(void)
+    SQLSelect<ResultType>* Select() override
     {
         if (_statement != nullptr)
         {
@@ -69,7 +67,7 @@ public:
      * @brief SQL insert query.
      * @return SQLInsert pointer.
      */
-    SQLInsert<ResultType>* Insert(void)
+    SQLInsert<ResultType>* Insert() override
     {
         if (_statement != nullptr)
         {
@@ -91,7 +89,7 @@ public:
      * @brief SQL update query.
      * @return SQLUpdate pointer.
      */
-    SQLUpdate<ResultType>* Update(void)
+    SQLUpdate<ResultType>* Update() override
     {
         if (_statement != nullptr)
         {
@@ -113,7 +111,7 @@ public:
      * @brief SQL delete query.
      * @return SQLDelete pointer.
      */
-    SQLDelete<ResultType>* Delete(void)
+    SQLDelete<ResultType>* Delete() override
     {
         if (_statement != nullptr)
         {
@@ -136,7 +134,7 @@ public:
      * @brief Changing table.
      * @param newTableName - new name of the table.
      */
-    void changeTable(const char* newTableName) noexcept
+    void changeTable(const char* newTableName) noexcept override
     {
         if (_statement != nullptr)
         {
@@ -150,23 +148,24 @@ public:
      * @brief Changing table.
      * @param newTableName - new name of the table.
      */
-    void changeTable(const std::string& newTableName) noexcept { changeTable(newTableName.c_str()); }
+    void changeTable(const std::string& newTableName) noexcept override { changeTable(newTableName.c_str()); }
 
 public:
     /**
      * @brief Get postgreAdapter object.
      * @return PostgreAdapter.
      */
-    [[nodiscard]] std::shared_ptr<IAdapter> getAdapter(void) const noexcept { return _adapter; }
+    [[nodiscard]] std::shared_ptr<IAdapter> getAdapter() const noexcept override { return _adapter; }
 
-    [[nodiscard]] Utility::DatabaseType getDatabaseType(void) const noexcept { return _databaseType; }
+    [[nodiscard]] Utility::DatabaseType getDatabaseType() const noexcept override { return _databaseType; }
 
-    [[nodiscard]] const std::string& getCurrentTableName(void) const noexcept { return _tableName; }
+    [[nodiscard]] const std::string& getCurrentTableName() const noexcept override { return _tableName; }
 
-    void clearStatement()
+    void clearStatement() override
     {
         delete _statement;
         _statement = nullptr;
     }
 };
+
 }  // namespace DataAccess

--- a/DataAccess/Public/Include/DataAccess/SQLStatements.hpp
+++ b/DataAccess/Public/Include/DataAccess/SQLStatements.hpp
@@ -163,9 +163,9 @@ template <typename ResultType>
 class SQLBase
 {
 protected:
-    Utility::SQLStatement     _statementType;
+    Utility::SQLStatement            _statementType;
     QueryBuilder<ResultType>& _currentBuilder;
-    std::ostringstream        _queryStream;
+    std::ostringstream               _queryStream;
 
 public:
     SQLBase(Utility::SQLStatement statement, QueryBuilder<ResultType>& table)
@@ -304,8 +304,8 @@ class SQLSelect : public SQLBase<ResultType>, public SQLWhereCondition<SQLSelect
 public:
     SQLSelect(QueryBuilder<ResultType>& table)
         : SQLBase<ResultType>(Utility::SQLStatement::ST_SELECT, table), SQLWhereCondition<SQLSelect<ResultType>>(this)
-    {
-    }
+        {
+        }
 
     virtual ~SQLSelect(void) = default;
 
@@ -711,8 +711,8 @@ class SQLUpdate : public SQLBase<ResultType>, public SQLWhereCondition<SQLUpdate
 public:
     SQLUpdate(QueryBuilder<ResultType>& table)
         : SQLBase<ResultType>(Utility::SQLStatement::ST_UPDATE, table), SQLWhereCondition<SQLUpdate<ResultType>>(this)
-    {
-    }
+        {
+        }
 
     virtual ~SQLUpdate(void) = default;
 


### PR DESCRIPTION
For the further development of ORM architecture, I see the point in the implementation of interfaces IQuery and IBuilder. In order to create an implementation between other databases and provide functionality to other databases that we will connect in the future.