### PR TITLE
Adding ArgParser Tests

### DIFF
--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -5,34 +5,34 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 {
     SECTION("Default constructor")
     {
-        std::vector<const char*> args = {"./juniorgram"};
+        std::vector<const char*> args {"./juniorgram"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 
     SECTION("Constructor with default arguments")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=65001", "--port=5432", "--dbname=juniorgram",
+        std::vector<const char*> args {"./juniorgram", "--serverport=65001", "--port=5432", "--dbname=juniorgram",
                                          "--hostaddr=127.0.0.1", "--user=postgres", "--password=postgres"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
     SECTION("Constructor with different arguments")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport:65003", "--port:6666", "--dbname:testdb",
+        std::vector<const char*> args {"./juniorgram", "--serverport:65003", "--port:6666", "--dbname:testdb",
                                          "--hostaddr:255.255.0.0", "--user:dbuser", "--password:dbpassword"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
     SECTION("Deliberate disregard for the value of the argument")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
+        std::vector<const char*> args {"./juniorgram", "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
                                          "--hostaddr=126.0.0.1", "--user=tester", "--password=tester"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 
     SECTION("Calling the helper flag")
     {
-        std::vector<const char*> args = {"./juniorgram", "--help"};
+        std::vector<const char*> args {"./juniorgram", "--help"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 }
@@ -41,32 +41,32 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Failed]")
 {
     SECTION("Duplicated keys in arguments throw an exception")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=65001", "--serverport=65001"};
+        std::vector<const char*> args {"./juniorgram", "--serverport=65001", "--serverport=65001"};
         CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 
     SECTION("Invalid arguments keys throw an exception")
     {
-        std::vector<const char*> args = {"./juniorgram", "any_flag", "test_flag"};
+        std::vector<const char*> args {"./juniorgram", "any_flag", "test_flag"};
         CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
     }
 
     SECTION("Number of keys without values throws an exception")
     {
-        std::vector<const char*> args = {"./juniorgram", "-m", "999"};
+        std::vector<const char*> args {"./juniorgram", "-m", "999"};
         CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
     }
 
-    SECTION("Calling the helper flag")
+    SECTION("Parsing incorrectly filled arguments")
     {
-        std::vector<const char*> args = {"./juniorgram", "--help"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+        std::vector<const char*> args { "66666", "test_flag", "126.0.0.1", "8989" };
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 }
 
 TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][Success]")
 { 
-    std::vector<const char*> args = {"./juniorgram"};
+    std::vector<const char*> args {"./juniorgram"};
     ArgParser                parser(static_cast<int>(args.size()), args.data());
 
     SECTION("Getting arguments with default pairs")
@@ -90,7 +90,7 @@ TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][
         std::vector<const char*> sectionArgs = {"./juniorgram", "--serverport=65003"};
         ArgParser                sectionParser(static_cast<int>(sectionArgs.size()), sectionArgs.data());
 
-        std::pair<std::string, std::string> serverPortPair("--serverport", "65003");
+        std::pair<std::string, std::string> serverPortPair{"--serverport", "65003"};
         REQUIRE(sectionParser.getPair("--serverport").second == serverPortPair.second);
     }
 

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch.hpp>
+
 #include <ArgParser.hpp>
 
 TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
@@ -47,7 +48,7 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         CHECK_NOTHROW(ArgParser(static_cast<int>(helperArgs.size()), helperArgs.data()));
     }
 
-    SECTION("Calling the other helper flag")
+    SECTION("Calling the abridged version of helper flag")
     {
         std::vector<const char*> helperArgs{"./juniorgram", "-h"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(helperArgs.size()), helperArgs.data()));
@@ -109,9 +110,10 @@ TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][
     {
         std::vector<const char*> sectionArgs = {"./juniorgram", "--serverport=65003"};
         ArgParser                sectionParser(static_cast<int>(sectionArgs.size()), sectionArgs.data());
+        REQUIRE_NOTHROW(sectionParser);
 
-        std::pair<std::string, std::string> serverPortPair{"--serverport", "65003"};
-        REQUIRE(sectionParser.getPair("--serverport").second == serverPortPair.second);
+        std::pair<std::string, std::string> otherPair{"--serverport", "65003"};
+        REQUIRE(sectionParser.getPair("--serverport").second == otherPair.second);
     }
 
     SECTION("Check the database flag pair with the default argument")

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -29,12 +29,12 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
-    //SECTION("Number limit 1")
-    //{
-    //    std::vector<const char*> args = {"./juniorgram", "--serverport=6666666", "--port=6666666",
-    //        "--dbname=otherdb", "--hostaddr=255.255.0.0", "--user=tester", "--password=tester"};
-    //    CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
-    //}
+    SECTION("deliberate disregard for the value of the argument")
+    {
+        std::vector<const char*> args = {"./juniorgram", "--serverport=6666666", "--port=6666666",
+            "--dbname=otherdb", "--hostaddr=255.255.0.0", "--user=tester", "--password=tester"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
+    }
 	
     SECTION("Invalid arguments keys throw an exception")
     {

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -16,30 +16,24 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
-    SECTION("Number of keys without values throws an exception")
-    {
-        std::vector<const char*> args = {"juniorgram", "-m"};
-        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::runtime_error);
-    }
-
-    SECTION("Calling the helper flag")
-    {
-        std::vector<const char*> args = {"./juniorgram", "--help"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
-    }
-
     SECTION("Constructor with different arguments")
     {
         std::vector<const char*> args = {"./juniorgram",           "--serverport=65003", "--port=6666", "--dbname=testdb",
-                                         "--hostaddr=255.255.0.0", "--user=tester",      "--password=tester"};
+                                         "--hostaddr=255.255.0.0", "--user=dbuser",      "--password=dbpassword"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
     SECTION("deliberate disregard for the value of the argument")
     {
         std::vector<const char*> args = {"./juniorgram",           "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
-                                         "--hostaddr=255.255.0.0", "--user=tester",        "--password=tester"};
+                                         "--hostaddr=126.0.0.1", "--user=tester",        "--password=tester"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+
+    SECTION("Duplicated keys in arguments throw an exception")
+    {
+        std::vector<const char*> args = {"./juniorgram", "--serverport=65001", "--serverport=65001", "--serverport=65001"};
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 
     SECTION("Invalid arguments keys throw an exception")
@@ -51,13 +45,19 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
     SECTION("Number of keys without values throws an exception")
     {
         std::vector<const char*> args = {"./juniorgram", "-m", "999"};
-        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::runtime_error);
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
     }
 
-    SECTION("Duplicated keys in arguments throw an exception")
+    SECTION("Number of keys without values throws an exception")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=65001", "--serverport=65001", "--serverport=65001"};
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+        std::vector<const char*> args = {"juniorgram", "-m"};
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
+    }
+
+    SECTION("Calling the helper flag")
+    {
+        std::vector<const char*> args = {"./juniorgram", "--help"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 }
 
@@ -87,7 +87,7 @@ TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][
         std::vector<const char*> sectionArgs = {"./juniorgram", "--serverport=65003"};
         ArgParser                sectionParser(static_cast<int>(sectionArgs.size()), sectionArgs.data());
 
-        std::pair<std::string, std::string> serverPortPair{"--serverport", "65003"};
+        std::pair<std::string, std::string> serverPortPair("--serverport", "65003");
         REQUIRE(sectionParser.getPair("--serverport").second == serverPortPair.second);
     }
 

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -56,38 +56,32 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 
 TEST_CASE("Constructor of ArgParser [ArgParser][Failed]")
 {
-    SECTION("Duplicated keys in arguments throw an exception")
-    {
-        std::vector<const char*> failedArgs {"./juniorgram", "--serverport=65001", "--serverport=65001"};
-        CHECK_THROWS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()));
-    }
+     SECTION("Duplicated keys in arguments throw an exception")
+     {
+         std::vector<const char*> failedArgs {"./juniorgram", "--serverport=65001", "--serverport=65001"};
+         CHECK_THROWS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()));
+     }
 
-    SECTION("Invalid arguments keys throw an exception")
-    {
-        std::vector<const char*> failedArgs {"./juniorgram", "any_flag", "test_flag"};
-        CHECK_THROWS_AS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()), std::exception);
-    }
+     SECTION("Invalid arguments keys throw an exception")
+     {
+         std::vector<const char*> failedArgs {"./juniorgram", "any_flag", "test_flag"};
+         CHECK_THROWS_AS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()), std::exception);
+     }
 
-    SECTION("Number of keys without values throws an exception")
-    {
-        std::vector<const char*> failedArgs {"./juniorgram", "-m", "999"};
-        CHECK_THROWS_AS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()), std::exception);
-    }
+     SECTION("Number of keys without values throws an exception")
+     {
+         std::vector<const char*> failedArgs {"./juniorgram", "-m", "999"};
+         CHECK_THROWS_AS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()), std::exception);
+     }
 
-    SECTION("Parsing incorrectly filled arguments")
-    { 
-        std::vector<const char*> failedArgs {"./juniorgram", 
-                                             "serverport=test_key", "port=test_key", 
-                                             "dbname=test_key",     "hostaddr=test_key",
-                                             "user=test_key",       "password=test_key"};
-        CHECK_THROWS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()));
-    }
-
-    SECTION("Parsing an unknown argument")
-    { 
-        std::vector<const char*> failedArgs {"./juniorgram", "--test_flag=666"};
-        CHECK_THROWS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()));
-    }
+     SECTION("Parsing incorrectly filled arguments")
+     {
+         std::vector<const char*> failedArgs {"./juniorgram",
+                                              "serverport=test_key", "port=test_key",
+                                              "dbname=test_key",     "hostaddr=test_key",
+                                              "user=test_key",       "password=test_key"};
+         CHECK_THROWS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()));
+     }
 }
 
 TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][Success]")

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -103,11 +103,6 @@ TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][
         REQUIRE(parser.getPair("--password") == passwordPair);
     }
 
-    SECTION("Getting an argument from a failed pair")
-    {
-        REQUIRE_THROWS_AS(parser.getPair(std::any_cast<std::string>(int("serverport"))), std::exception);
-    }
-
     SECTION("Taking a bad flag") 
     { 
         CHECK_THROWS_AS(parser.getPair("any_flag"), std::exception);

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -19,16 +19,6 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         CHECK_NOTHROW(ArgParser(static_cast<int>(defaultArgs.size()), defaultArgs.data()));
     }
 
-    SECTION("Constructor with different arguments and other initialization")
-    {
-        std::vector<const char*> differentArgs {"./juniorgram", 
-                                                "--serverport:65003",
-                                                "--port:6666", "--dbname:testdb",
-                                                "--hostaddr:255.255.0.0", 
-                                                "--user:dbuser", "--password:dbpassword"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(differentArgs.size()), differentArgs.data()));
-    }
-
     SECTION("Constructor with other initialization")
     {
         std::vector<const char*> otherDefaultArgs{"./juniorgram",

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -9,24 +9,45 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 
-    SECTION("Constructor with default arguments")
+    SECTION("Constructor with default arguments and default initialization")
     {
-        std::vector<const char*> defaultArgs {"./juniorgram", "--serverport=65001", "--port=5432", "--dbname=juniorgram",
-                                         "--hostaddr=127.0.0.1", "--user=postgres", "--password=postgres"};
+        std::vector<const char*> defaultArgs {"./juniorgram", 
+                                              "--serverport=65001", 
+                                              "--port=5432", "--dbname=juniorgram",
+                                              "--hostaddr=127.0.0.1", 
+                                              "--user=postgres", "--password=postgres"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(defaultArgs.size()), defaultArgs.data()));
     }
 
-    SECTION("Constructor with different arguments")
+    SECTION("Constructor with different arguments and other initialization")
     {
-        std::vector<const char*> differentArgs {"./juniorgram", "--serverport:65003", "--port:6666", "--dbname:testdb",
-                                         "--hostaddr:255.255.0.0", "--user:dbuser", "--password:dbpassword"};
+        std::vector<const char*> differentArgs {"./juniorgram", 
+                                                "--serverport:65003",
+                                                "--port:6666", "--dbname:testdb",
+                                                "--hostaddr:255.255.0.0", 
+                                                "--user:dbuser", "--password:dbpassword"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(differentArgs.size()), differentArgs.data()));
+    }
+
+    SECTION("Constructor with other initialization")
+    {
+        std::vector<const char*> otherDefaultArgs{"./juniorgram",
+                                             "--serverport", "65001",
+                                             "--port", "5432",
+                                             "--dbname", "juniorgram",
+                                             "--hostaddr", "127.0.0.1",
+                                             "--user", "postgres", 
+                                             "--password", "postgres"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(otherDefaultArgs.size()), otherDefaultArgs.data()));
     }
 
     SECTION("Deliberate disregard for the value of the argument")
     {
-        std::vector<const char*> limitedArgs {"./juniorgram", "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
-                                         "--hostaddr=126.0.0.1", "--user=tester", "--password=tester"};
+        std::vector<const char*> limitedArgs {"./juniorgram", 
+                                              "--serverport=6666666", 
+                                              "--port=6666666", "--dbname=otherdb",
+                                              "--hostaddr=126.0.0.1", 
+                                              "--user=tester", "--password=tester"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(limitedArgs.size()), limitedArgs.data()));
     }
 

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -16,6 +16,12 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
+    SECTION("Calling the helper flag")
+    {
+        std::vector<const char*> args = {"./juniorgram", "--help"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+
     SECTION("Constructor with different arguments")
     {
         std::vector<const char*> args = {"./juniorgram", "--serverport=65003", "--port=6666", 
@@ -34,6 +40,12 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
     {
         std::vector<const char*> args = {"./juniorgram", "-m", "any_flag=test", "666666"};
         CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
+    }
+
+    SECTION("Number of keys without values throws an exception")
+    {
+        std::vector<const char*> args = {"./juniorgram", "-m", "999"};
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::runtime_error);
     }
 
     SECTION("Duplicated keys in arguments throw an exception")
@@ -64,7 +76,7 @@ TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][
         REQUIRE(parser.getPair("--serverport") == serverPortPair);
     }
 
-    SECTION("Check the server port flag pair with the other argument")
+    SECTION("Check the any flag pair with the other argument")
     {
         std::vector<const char*> sectionArgs = {"./juniorgram", "--serverport=65003"};
         ArgParser                sectionParser(static_cast<int>(sectionArgs.size()), sectionArgs.data());

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Failed]")
 
     SECTION("Parsing incorrectly filled arguments")
     {
-        std::vector<const char*> args { "66666", "test_flag", "126.0.0.1", "8989" };
+        std::vector<const char*> args { "66666", "test_flag", "password", "8989" };
         CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -43,8 +43,14 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 
     SECTION("Calling the helper flag")
     {
-        std::vector<const char*> args {"./juniorgram", "--help"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+        std::vector<const char*> helperArgs {"./juniorgram", "--help"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(helperArgs.size()), helperArgs.data()));
+    }
+
+    SECTION("Calling the other helper flag")
+    {
+        std::vector<const char*> helperArgs{"./juniorgram", "-h"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(helperArgs.size()), helperArgs.data()));
     }
 }
 

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -11,46 +11,49 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 
     SECTION("Constructor with default arguments")
     {
-        std::vector<const char*> args = {"./juniorgram",         "--serverport=65001", "--port=5432", "--dbname=juniorgram",
-                                         "--hostaddr=127.0.0.1", "--user=postgres",    "--password=postgres"};
+        std::vector<const char*> args = {"./juniorgram", "--serverport=65001", "--port=5432", "--dbname=juniorgram",
+                                         "--hostaddr=127.0.0.1", "--user=postgres", "--password=postgres"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
     SECTION("Constructor with different arguments")
     {
-        std::vector<const char*> args = {"./juniorgram",           "--serverport=65003", "--port=6666", "--dbname=testdb",
-                                         "--hostaddr=255.255.0.0", "--user=dbuser",      "--password=dbpassword"};
+        std::vector<const char*> args = {"./juniorgram", "--serverport:65003", "--port:6666", "--dbname:testdb",
+                                         "--hostaddr:255.255.0.0", "--user:dbuser", "--password:dbpassword"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
-    SECTION("deliberate disregard for the value of the argument")
+    SECTION("Deliberate disregard for the value of the argument")
     {
-        std::vector<const char*> args = {"./juniorgram",           "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
-                                         "--hostaddr=126.0.0.1", "--user=tester",        "--password=tester"};
+        std::vector<const char*> args = {"./juniorgram", "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
+                                         "--hostaddr=126.0.0.1", "--user=tester", "--password=tester"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 
+    SECTION("Calling the helper flag")
+    {
+        std::vector<const char*> args = {"./juniorgram", "--help"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+}
+
+TEST_CASE("Constructor of ArgParser [ArgParser][Failed]")
+{
     SECTION("Duplicated keys in arguments throw an exception")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=65001", "--serverport=65001", "--serverport=65001"};
+        std::vector<const char*> args = {"./juniorgram", "--serverport=65001", "--serverport=65001"};
         CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 
     SECTION("Invalid arguments keys throw an exception")
     {
-        std::vector<const char*> args = {"./juniorgram", "-m", "any_flag=test", "666666"};
+        std::vector<const char*> args = {"./juniorgram", "any_flag", "test_flag"};
         CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
     }
 
     SECTION("Number of keys without values throws an exception")
     {
         std::vector<const char*> args = {"./juniorgram", "-m", "999"};
-        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
-    }
-
-    SECTION("Number of keys without values throws an exception")
-    {
-        std::vector<const char*> args = {"juniorgram", "-m"};
         CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
     }
 

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -11,23 +11,23 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 
     SECTION("Constructor with default arguments")
     {
-        std::vector<const char*> args {"./juniorgram", "--serverport=65001", "--port=5432", "--dbname=juniorgram",
+        std::vector<const char*> defaultArgs {"./juniorgram", "--serverport=65001", "--port=5432", "--dbname=juniorgram",
                                          "--hostaddr=127.0.0.1", "--user=postgres", "--password=postgres"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
+        CHECK_NOTHROW(ArgParser(static_cast<int>(defaultArgs.size()), defaultArgs.data()));
     }
 
     SECTION("Constructor with different arguments")
     {
-        std::vector<const char*> args {"./juniorgram", "--serverport:65003", "--port:6666", "--dbname:testdb",
+        std::vector<const char*> differentArgs {"./juniorgram", "--serverport:65003", "--port:6666", "--dbname:testdb",
                                          "--hostaddr:255.255.0.0", "--user:dbuser", "--password:dbpassword"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
+        CHECK_NOTHROW(ArgParser(static_cast<int>(differentArgs.size()), differentArgs.data()));
     }
 
     SECTION("Deliberate disregard for the value of the argument")
     {
-        std::vector<const char*> args {"./juniorgram", "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
+        std::vector<const char*> limitedArgs {"./juniorgram", "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
                                          "--hostaddr=126.0.0.1", "--user=tester", "--password=tester"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+        CHECK_NOTHROW(ArgParser(static_cast<int>(limitedArgs.size()), limitedArgs.data()));
     }
 
     SECTION("Calling the helper flag")
@@ -60,42 +60,6 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Failed]")
     SECTION("Parsing incorrectly filled arguments")
     {
         std::vector<const char*> args { "66666", "test_flag", "password", "8989" };
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
-    }
-
-    SECTION("Bad parsing 1")
-    {
-        std::vector<const char*> args{"--serverport:serverport"};
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
-    }
-
-    SECTION("Bad parsing 2")
-    {
-        std::vector<const char*> args{"--port:port"};
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
-    }
-
-    SECTION("Bad parsing 3")
-    {
-        std::vector<const char*> args{"--dbname:666"};
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
-    }
-
-    SECTION("Bad parsing 4")
-    {
-        std::vector<const char*> args{"--hostaddr:hostaddr"};
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
-    }
-
-    SECTION("Bad parsing 5")
-    {
-        std::vector<const char*> args{"--user:|||"};
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
-    }
-
-    SECTION("Bad parsing 6")
-    {
-        std::vector<const char*> args{"--password:|||"};
         CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 }

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -62,6 +62,42 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Failed]")
         std::vector<const char*> args { "66666", "test_flag", "126.0.0.1", "8989" };
         CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
     }
+
+    SECTION("Bad parsing 1")
+    {
+        std::vector<const char*> args{"--serverport:serverport"};
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+
+    SECTION("Bad parsing 2")
+    {
+        std::vector<const char*> args{"--port:port"};
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+
+    SECTION("Bad parsing 3")
+    {
+        std::vector<const char*> args{"--dbname:666"};
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+
+    SECTION("Bad parsing 4")
+    {
+        std::vector<const char*> args{"--hostaddr:hostaddr"};
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+
+    SECTION("Bad parsing 5")
+    {
+        std::vector<const char*> args{"--user:|||"};
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+
+    SECTION("Bad parsing 6")
+    {
+        std::vector<const char*> args{"--password:|||"};
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
 }
 
 TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][Success]")

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         std::vector<const char*> otherDefaultArgs{"./juniorgram",
                                              "--serverport", "65001",
                                              "--port", "5432",
-                                             "--dbname", "juniorgram",
+                                             "--dbname", "testdb",
                                              "--hostaddr", "127.0.0.1",
                                              "--user", "postgres", 
                                              "--password", "postgres"};
@@ -52,26 +52,35 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Failed]")
 {
     SECTION("Duplicated keys in arguments throw an exception")
     {
-        std::vector<const char*> args {"./juniorgram", "--serverport=65001", "--serverport=65001"};
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+        std::vector<const char*> failedArgs {"./juniorgram", "--serverport=65001", "--serverport=65001"};
+        CHECK_THROWS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()));
     }
 
     SECTION("Invalid arguments keys throw an exception")
     {
-        std::vector<const char*> args {"./juniorgram", "any_flag", "test_flag"};
-        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
+        std::vector<const char*> failedArgs {"./juniorgram", "any_flag", "test_flag"};
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()), std::exception);
     }
 
     SECTION("Number of keys without values throws an exception")
     {
-        std::vector<const char*> args {"./juniorgram", "-m", "999"};
-        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::exception);
+        std::vector<const char*> failedArgs {"./juniorgram", "-m", "999"};
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()), std::exception);
     }
 
     SECTION("Parsing incorrectly filled arguments")
-    {
-        std::vector<const char*> args { "66666", "test_flag", "password", "8989" };
-        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+    { 
+        std::vector<const char*> failedArgs {"./juniorgram", 
+                                             "serverport=test_key", "port=test_key", 
+                                             "dbname=test_key",     "hostaddr=test_key",
+                                             "user=test_key",       "password=test_key"};
+        CHECK_THROWS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()));
+    }
+
+    SECTION("Parsing an unknown argument")
+    { 
+        std::vector<const char*> failedArgs {"./juniorgram", "--test_flag=666"};
+        CHECK_THROWS(ArgParser(static_cast<int>(failedArgs.size()), failedArgs.data()));
     }
 }
 

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -16,6 +16,12 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
+    SECTION("Number of keys without values throws an exception")
+    {
+        std::vector<const char*> args = {"juniorgram", "-m"};
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::runtime_error);
+    }
+
     SECTION("Calling the helper flag")
     {
         std::vector<const char*> args = {"./juniorgram", "--help"};
@@ -29,13 +35,48 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
-    SECTION("deliberate disregard for the value of the argument")
+    SECTION("deliberate disregard for the value of the argument of a server port")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=6666666", "--port=6666666",
-            "--dbname=otherdb", "--hostaddr=255.255.0.0", "--user=tester", "--password=tester"};
+        std::vector<const char*> args = {"./juniorgram", "--serverport=6666666"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
+    }
+
+    SECTION("deliberate disregard for the value of the argument of a database port")
+    {   
+        std::vector<const char*> args = {"./juniorgram", "--port=6666666"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
+    }
+
+    SECTION("deliberate disregard for the value of the argument of a database")
+    {
+        {
+            std::vector<const char*> args = {"./juniorgram", "--dbname=testdb"};
+            CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+        }
+        {
+            std::vector<const char*> args = {"./juniorgram", "--dbname=otherdb"};
+            CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+        }
+    }
+
+    SECTION("deliberate disregard for the value of the argument of a host address")
+    {
+        std::vector<const char*> args = {"./juniorgram", "--hostaddr=255.255.0.0"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 	
+    SECTION("deliberate disregard for the value of the argument of a database user")
+    {   
+        std::vector<const char*> args = {"./juniorgram", "--user=tester"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
+    }
+
+    SECTION("deliberate disregard for the value of the argument of a database password")
+    {
+        std::vector<const char*> args = {"./juniorgram", "--password=tester"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
+    }
+
     SECTION("Invalid arguments keys throw an exception")
     {
         std::vector<const char*> args = {"./juniorgram", "-m", "any_flag=test", "666666"};

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -11,8 +11,8 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 
     SECTION("Constructor with default arguments")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=65001", "--port=5432", 
-            "--dbname=juniorgram", "--hostaddr=127.0.0.1", "--user=postgres", "--password=postgres"};
+        std::vector<const char*> args = {"./juniorgram",         "--serverport=65001", "--port=5432", "--dbname=juniorgram",
+                                         "--hostaddr=127.0.0.1", "--user=postgres",    "--password=postgres"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
@@ -30,51 +30,16 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 
     SECTION("Constructor with different arguments")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=65003", "--port=6666", 
-            "--dbname=testdb", "--hostaddr=255.255.0.0", "--user=tester", "--password=tester"};
+        std::vector<const char*> args = {"./juniorgram",           "--serverport=65003", "--port=6666", "--dbname=testdb",
+                                         "--hostaddr=255.255.0.0", "--user=tester",      "--password=tester"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
     }
 
-    SECTION("deliberate disregard for the value of the argument of a server port")
+    SECTION("deliberate disregard for the value of the argument")
     {
-        std::vector<const char*> args = {"./juniorgram", "--serverport=6666666"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
-    }
-
-    SECTION("deliberate disregard for the value of the argument of a database port")
-    {   
-        std::vector<const char*> args = {"./juniorgram", "--port=6666666"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
-    }
-
-    SECTION("deliberate disregard for the value of the argument of a database")
-    {
-        {
-            std::vector<const char*> args = {"./juniorgram", "--dbname=testdb"};
-            CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
-        }
-        {
-            std::vector<const char*> args = {"./juniorgram", "--dbname=otherdb"};
-            CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
-        }
-    }
-
-    SECTION("deliberate disregard for the value of the argument of a host address")
-    {
-        std::vector<const char*> args = {"./juniorgram", "--hostaddr=255.255.0.0"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
-    }
-	
-    SECTION("deliberate disregard for the value of the argument of a database user")
-    {   
-        std::vector<const char*> args = {"./juniorgram", "--user=tester"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
-    }
-
-    SECTION("deliberate disregard for the value of the argument of a database password")
-    {
-        std::vector<const char*> args = {"./juniorgram", "--password=tester"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()),args.data()));
+        std::vector<const char*> args = {"./juniorgram",           "--serverport=6666666", "--port=6666666", "--dbname=otherdb",
+                                         "--hostaddr=255.255.0.0", "--user=tester",        "--password=tester"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 
     SECTION("Invalid arguments keys throw an exception")

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
                                              "--serverport", "65003",
                                              "--port", "6432",
                                              "--dbname", "testdb",
-                                             "--hostaddr", "200.0.0.1",
+                                             "--hostaddr", "0.0.0.0",
                                              "--user", "user", 
                                              "--password", "user"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(otherDefaultArgs.size()), otherDefaultArgs.data()));

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -11,23 +11,23 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 
     SECTION("Constructor with default arguments and default initialization")
     {
-        std::vector<const char*> defaultArgs {"./juniorgram", 
+       std::vector<const char*> defaultArgs {"./juniorgram", 
                                               "--serverport=65001", 
                                               "--port=5432", "--dbname=juniorgram",
                                               "--hostaddr=127.0.0.1", 
                                               "--user=postgres", "--password=postgres"};
-        CHECK_NOTHROW(ArgParser(static_cast<int>(defaultArgs.size()), defaultArgs.data()));
+       CHECK_NOTHROW(ArgParser(static_cast<int>(defaultArgs.size()), defaultArgs.data()));
     }
 
     SECTION("Constructor with other initialization")
     {
         std::vector<const char*> otherDefaultArgs{"./juniorgram",
-                                             "--serverport", "65001",
-                                             "--port", "5432",
+                                             "--serverport", "65003",
+                                             "--port", "6432",
                                              "--dbname", "testdb",
-                                             "--hostaddr", "127.0.0.1",
-                                             "--user", "postgres", 
-                                             "--password", "postgres"};
+                                             "--hostaddr", "200.0.0.1",
+                                             "--user", "user", 
+                                             "--password", "user"};
         CHECK_NOTHROW(ArgParser(static_cast<int>(otherDefaultArgs.size()), otherDefaultArgs.data()));
     }
 

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
 
     SECTION("Duplicated keys in arguments throw an exception")
     {
-        std::vector<const char*> args = {"juniorgram", "--any_flag", "any_flag", "any_flag"};
+        std::vector<const char*> args = {"juniorgram", "--any_flag", "--any_flag", "--any_flag"};
         CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
     }
 }

--- a/Server/Server.Test/ArgParserTests.cpp
+++ b/Server/Server.Test/ArgParserTests.cpp
@@ -1,0 +1,92 @@
+#include <catch2/catch.hpp>
+#include <ArgParser.hpp>
+
+TEST_CASE("Constructor of ArgParser [ArgParser][Success]")
+{
+    SECTION("Default constructor")
+    {
+        std::vector<const char*> args = {"juniorgram"};
+        CHECK_NOTHROW(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+
+    SECTION("Number of keys without values throws an exception")
+    {
+        std::vector<const char*> args = {"juniorgram", "--any_flag"};
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::runtime_error);
+    }
+
+    SECTION("Number of keys without values throws an exception")
+    {
+        std::vector<const char*> args = {"juniorgram", "-m", "999"};
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::runtime_error);
+    }
+	
+    SECTION("Invalid arguments keys throw an exception")
+    {
+        std::vector<const char*> args = {"juniorgram", "-m", "--any_flag", "666666"};
+        CHECK_THROWS_AS(ArgParser(static_cast<int>(args.size()), args.data()), std::runtime_error);
+    }
+
+    SECTION("Duplicated keys in arguments throw an exception")
+    {
+        std::vector<const char*> args = {"juniorgram", "--any_flag", "any_flag", "any_flag"};
+        CHECK_THROWS(ArgParser(static_cast<int>(args.size()), args.data()));
+    }
+}
+
+TEST_CASE("Method of obtaining a pair of arguments of the argparser [ArgParser][Success]")
+{ 
+    std::vector<const char*> args = {"juniorgram"};
+    ArgParser                parser(static_cast<int>(args.size()), args.data());
+
+    SECTION("Getting arguments with default pairs")
+    {
+        CHECK_NOTHROW(parser.getPair("--serverport"));
+        CHECK_NOTHROW(parser.getPair("--dbname"));
+        CHECK_NOTHROW(parser.getPair("--hostaddr"));
+        CHECK_NOTHROW(parser.getPair("--port"));
+        CHECK_NOTHROW(parser.getPair("--user"));
+        CHECK_NOTHROW(parser.getPair("--password"));
+    }
+    
+    SECTION("Check the server port flag pair with the default argument") 
+    { 
+        std::pair<std::string,std::string> serverPortPair{"--serverport", "65001"};
+        REQUIRE(parser.getPair("--serverport") == serverPortPair);
+    }
+
+    SECTION("Check the database flag pair with the default argument")
+    {
+        std::pair<std::string,std::string> dbnamePair{"--dbname", "juniorgram"};
+        REQUIRE(parser.getPair("--dbname") == dbnamePair);
+    }
+
+    SECTION("Check the host address flag pair with the default argument")
+    {
+        std::pair<std::string,std::string> hostaddrPair{"--hostaddr", "127.0.0.1"};
+        REQUIRE(parser.getPair("--hostaddr") == hostaddrPair);
+    }
+
+    SECTION("Check the database port flag pair with the default argument")
+    {
+        std::pair<std::string, std::string> dbportPair{"--port", "5432"};
+        REQUIRE(parser.getPair("--port") == dbportPair);
+    }
+
+    SECTION("Check the database user flag pair with the default argument")
+    {
+        std::pair<std::string, std::string> userPair{"--user", "postgres"};
+        REQUIRE(parser.getPair("--user") == userPair);
+    }
+
+    SECTION("Check the database password flag pair with the default argument")
+    {
+        std::pair<std::string, std::string> passwordPair{"--password", "postgres"};
+        REQUIRE(parser.getPair("--password") == passwordPair);
+    }
+
+    SECTION("Taking a bad flag") 
+    { 
+        CHECK_THROWS_AS(parser.getPair("--any_flag"), std::exception);
+    }
+}

--- a/Server/Server.Test/CMakeLists.txt
+++ b/Server/Server.Test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TARGET Server.Test)
 set(OUTPUT_NAME Server.Test)
 
 set(SOURCE_FILES
+		ArgParserTests.cpp
 		ServerMessageTests.cpp
 		ServerDefaultTests.cpp
 		ServerChannelTests.cpp


### PR DESCRIPTION
Conclusions on reserch coverage of the remaining 30 percent: there are methods on the ArgParser.hpp side that take other data types, the example parse_args can take a vector of strings, when in our variant we specifically parse arguments via argc and argv. 
Consequently, covering the other 30 percent is not a possibility, based on the implementation. 
Maybe I haven't considered something, I'm waiting for your thoughts on this.