### PR TITLE
Improving ArgParser.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CXX_EXTENSIONS off)
 
-# Oprions
+# Options
 option(ENABLE_CCACHE        "Enable the usage of Ccache."           ON)
 option(ENABLE_WARNINGS      "Enable to add warnings to a target."   ON)
 

--- a/Server/Server.Core/Server.Core.Static/ArgParser.hpp
+++ b/Server/Server.Core/Server.Core.Static/ArgParser.hpp
@@ -46,11 +46,6 @@ public:
                 auto port = static_cast<uint32_t>(std::stoi(value));
                 if (port > std::numeric_limits<uint16_t>::max())
                 {
-                    Base::Logger::FileLogger::getInstance().log
-                    (
-                        "Bad port value", 
-                        Base::Logger::LogLevel::ERR
-                    );
                     return std::to_string(65001);
                 }
                 return std::to_string(port);
@@ -63,11 +58,6 @@ public:
                 auto port = static_cast<uint32_t>(std::stoi(value));
                 if (port > std::numeric_limits<uint16_t>::max())
                 {
-                    Base::Logger::FileLogger::getInstance().log
-                    (
-                        "Bad DataBase port value", 
-                        Base::Logger::LogLevel::ERR
-                    );
                     return std::to_string(5432);
                 }
                 return std::to_string(port);

--- a/Server/Server.Core/Server.Core.Static/ArgParser.hpp
+++ b/Server/Server.Core/Server.Core.Static/ArgParser.hpp
@@ -7,7 +7,7 @@
 * @class ArgParser.
 * @brief This class parses arguments with which application is started.
 * @details
-* For example: "--serverport=65001 --port=5432 --dbname=juniorgram --hostaddr=127.0.0.1 --user=postgres --password=postgres".
+* For example: "--serverport=65001", "--port=5432", "--dbname=juniorgram", "--hostaddr=127.0.0.1", "--user=postgres", "--password=postgres".
 * Sending the port to the Server class constructor and list of all arguments to the PostgreAdapter Instance Method.
 */
 class ArgParser

--- a/Server/Server.Core/Server.Core.Static/ArgParser.hpp
+++ b/Server/Server.Core/Server.Core.Static/ArgParser.hpp
@@ -4,37 +4,38 @@
 #include <FileLogger.hpp>
 
 /**
- * @class ArgParser.
- * @brief This class parses arguments with which application is started.
- * @details
- * For example: "--serverport 5432 --port 65001 --dbname juniorgram --hostaddr 127.0.0.1 --user postgres --password postgres".
- * Sending the port to the Server class constructor and list of all arguments to the PostgreAdapter Instance Method.
- */
+* @class ArgParser.
+* @brief This class parses arguments with which application is started.
+* @details
+* For example: "--serverport=65001 --port=5432 --dbname=juniorgram --hostaddr=127.0.0.1 --user=postgres --password=postgres".
+* Sending the port to the Server class constructor and list of all arguments to the PostgreAdapter Instance Method.
+*/
 class ArgParser
 {
 public:
     /**
-     * @brief It's deleted default constructor.
-     * @details There is no need to use this.
-     */
+    * @brief It's deleted default constructor.
+    * @details There is no need to use this.
+    */
     ArgParser() = delete;
    
     /**
-     * @brief It's deleted copy constructor.
-     * @details There is no need to use this.
-     */
+    * @brief It's deleted copy constructor.
+    * @details There is no need to use this.
+    */
     ArgParser(const ArgParser&) = delete;
    
     /**
-     * @brief Used to take parameters from main function.
-     * @details Parses arguments which were set when application was run.
-     * @param int argc(amount of arguments), const char** argv(C-string arguments).
-     */
+    * @brief Used to take parameters from main function.
+    * @details Parses arguments which were set when application was run.
+    * @param int argc(amount of arguments), const char** argv(C-string arguments).
+    */
     explicit ArgParser(int argc, const char** argv) 
     {
         _argParser = argparse::ArgumentParser("ServerArguments", "0.6",
         argparse::default_arguments::none);
 
+        _argParser.set_assign_chars("=");
         _argParser.add_description("Server side of juniorgram messenger. Just have a fun!");
         _argParser.add_epilog("Some parts of the program may be configured by default.");
 
@@ -42,7 +43,7 @@ public:
             .default_value<std::string>("65001")
             .help("Set the port value for server needs")
             .action([](const std::string& value) -> std::string {
-                uint16_t port = static_cast<uint16_t>(std::stoi(value));
+                auto port = static_cast<uint32_t>(std::stoi(value));
                 if (port > std::numeric_limits<uint16_t>::max())
                 {
                     Base::Logger::FileLogger::getInstance().log
@@ -59,7 +60,7 @@ public:
             .default_value<std::string>("5432")
             .help("Set the database port value")
             .action([](const std::string& value) -> std::string {
-                uint16_t port = static_cast<uint16_t>(std::stoi(value));
+                auto port = static_cast<uint32_t>(std::stoi(value));
                 if (port > std::numeric_limits<uint16_t>::max())
                 {
                     Base::Logger::FileLogger::getInstance().log
@@ -107,7 +108,6 @@ public:
         _argParser.add_argument("-h", "--help")
             .action([=](const std::string&) {
                 std::cout << _argParser << std::endl;
-                std::exit(0);
             })
             .default_value(false)
             .help("shows help message")
@@ -125,7 +125,7 @@ public:
                 err.what(), 
                 Base::Logger::LogLevel::ERR
             );
-            std::exit(1);
+            throw;
         }
     }
 

--- a/cmake/ConanModule.cmake
+++ b/cmake/ConanModule.cmake
@@ -24,7 +24,7 @@ conan_cmake_configure(REQUIRES asio/1.18.1
                                libpqxx/7.7.4
                                nlohmann_json/3.9.1
                                yas/7.0.5
-                               argparse/2.4
+                               argparse/2.9
                     GENERATORS cmake_find_package_multi)
 
 # This detects system settings such as platform, compiler, etc.


### PR DESCRIPTION
Fixed an overflow problem, as well as an intuitiveness correction in the use of parser arguments.
The argparse library has been updated to version 2.9.